### PR TITLE
fixed Opcode Filtering to allow Opcodes > 9

### DIFF
--- a/SilkETW/Program.cs
+++ b/SilkETW/Program.cs
@@ -221,12 +221,21 @@ namespace SilkETW
                 {
                     try
                     {
-                        SilkUtility.FilterValueObject = byte.Parse(FilterValue);
-                        if ((byte)SilkUtility.FilterValueObject > 9)
+                        UInt32 opcode;
+                        if (FilterValue.StartsWith("0x"))
                         {
-                            SilkUtility.ReturnStatusMessage("[!] Opcode outside valid range (0-9)", ConsoleColor.Red);
+                            opcode = Convert.ToUInt32(FilterValue, 16);
+                        }
+                        else
+                        {
+                            opcode = Convert.ToUInt32(FilterValue);
+                        }
+                        if (opcode > byte.MaxValue)
+                        {
+                            SilkUtility.ReturnStatusMessage("[!] Opcode outside valid range (0-255)", ConsoleColor.Red);
                             return;
                         }
+                        SilkUtility.FilterValueObject = Convert.ToByte(opcode);
                     }
                     catch
                     {


### PR DESCRIPTION
Fixes this issue: https://github.com/fireeye/SilkETW/issues/13

When filtering by opcode, e.g. -f Opcode -fv 2, you limit the possible opcode to filter on to be 0-9. However in the underlying ETW API, an Opcode is an UCHAR, so it can be 0-255